### PR TITLE
Update docker go build version to 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile References: https://docs.docker.com/engine/reference/builder/
 
 # Start from the latest golang base image
-FROM golang:1.20-alpine as builder
+FROM golang:1.22-alpine as builder
 
 # Set the Current Working Directory inside the container
 WORKDIR /app


### PR DESCRIPTION
While trying to use the binary from [ghcr.io/swaggo/swag:v1.16.3](https://github.com/swaggo/swag/pkgs/container/swag/173501427?tag=v1.16.3) I encountered an infinite error loop:
```
/usr/local/go/src/internal/syscall/unix/at_wasip1.go:12:2: UTIME_OMIT redeclared in this block
/usr/local/go/src/internal/syscall/unix/at_sysnum_linux.go:18:2:        other declaration of UTIME_OMIT
/usr/local/go/src/time/zoneinfo_wasip1.go:8:5: platformZoneSources redeclared in this block
/usr/local/go/src/time/zoneinfo_unix.go:21:5:   other declaration of platformZoneSources
/usr/local/go/src/time/zoneinfo_wasip1.go:10:6: initLocal redeclared in this block
/usr/local/go/src/time/zoneinfo_unix.go:28:6:   other declaration of initLocal
/usr/local/go/src/internal/poll/fd_wasip1.go:13:6: SysFile redeclared in this block
/usr/local/go/src/internal/poll/fd_unixjs.go:11:6:      other declaration of SysFile
/usr/local/go/src/internal/poll/fd_wasip1.go:87:6: dupCloseOnExecOld redeclared in this block
/usr/local/go/src/internal/poll/fd_unixjs.go:29:6:      other declaration of dupCloseOnExecOld
/usr/local/go/src/internal/poll/fd_wasip1.go:44:19: method SysFile.init already declared at /usr/local/go/src/internal/poll/fd_unixjs.go:16:19
/usr/local/go/src/internal/poll/fd_wasip1.go:56:19: method SysFile.destroy already declared at /usr/local/go/src/internal/poll/fd_unixjs.go:18:19
/usr/local/go/src/internal/poll/fd_wasip1.go:92:15: method FD.Fchdir already declared at /usr/local/go/src/internal/poll/fd_unixjs.go:41:15
/usr/local/go/src/internal/poll/fd_wasip1.go:123:15: method FD.ReadDirent already declared at /usr/local/go/src/internal/poll/fd_unixjs.go:52:15
/usr/local/go/src/internal/poll/fd_wasip1.go:164:15: method FD.Seek already declared at /usr/local/go/src/internal/poll/fd_unixjs.go:73:15
/usr/local/go/src/internal/poll/fd_wasip1.go:103:50: undefined: syscall.Dircookie
/usr/local/go/src/internal/poll/fd_wasip1.go:45:7: s.RefCountPtr undefined (type *SysFile has no field or method RefCountPtr)
/usr/local/go/src/internal/poll/fd_wasip1.go:46:5: s.RefCount undefined (type *SysFile has no field or method RefCount)
/usr/local/go/src/internal/poll/fd_wasip1.go:47:22: s.RefCount undefined (type *SysFile has no field or method RefCount)
/usr/local/go/src/internal/poll/fd_wasip1.go:47:5: s.RefCountPtr undefined (type *SysFile has no field or method RefCountPtr)
/usr/local/go/src/internal/poll/fd_wasip1.go:52:20: s.RefCountPtr undefined (type *SysFile has no field or method RefCountPtr)
/usr/local/go/src/internal/poll/fd_wasip1.go:53:32: s.RefCountPtr undefined (type *SysFile has no field or method RefCountPtr)
/usr/local/go/src/internal/poll/fd_wasip1.go:53:17: unknown field RefCountPtr in struct literal of type SysFile
/usr/local/go/src/internal/poll/fd_wasip1.go:57:7: s.RefCountPtr undefined (type *SysFile has no field or method RefCountPtr)
/usr/local/go/src/internal/poll/fd_wasip1.go:57:47: s.RefCountPtr undefined (type *SysFile has no field or method RefCountPtr)
/usr/local/go/src/internal/poll/fd_wasip1.go:97:26: fd.Path undefined (type *FD has no field or method Path)
/usr/local/go/src/internal/poll/fd_wasip1.go:109:21: undefined: syscall.ReadDir
/usr/local/go/src/internal/poll/fd_wasip1.go:124:31: fd.Dircookie undefined (type *FD has no field or method Dircookie)
/usr/local/go/src/internal/poll/fd_wasip1.go:149:26: undefined: syscall.Dircookie
/usr/local/go/src/internal/poll/fd_wasip1.go:149:6: fd.Dircookie undefined (type *FD has no field or method Dircookie)
/usr/local/go/src/internal/poll/fd_wasip1.go:172:22: undefined: syscall.Filetype
/usr/local/go/src/internal/poll/fd_wasip1.go:172:53: fd.Filetype undefined (type *FD has no field or method Filetype)
/usr/local/go/src/internal/poll/fd_wasip1.go:174:25: undefined: syscall.FILETYPE_UNKNOWN
/usr/local/go/src/internal/poll/fd_wasip1.go:179:19: stat.Filetype undefined (type "syscall".Stat_t has no field or method Filetype)
/usr/local/go/src/internal/poll/fd_wasip1.go:180:26: fd.Filetype undefined (type *FD has no field or method Filetype)
/usr/local/go/src/internal/poll/fd_wasip1.go:183:25: undefined: syscall.FILETYPE_DIRECTORY
/usr/local/go/src/internal/poll/fd_wasip1.go:188:7: fd.Dircookie undefined (type *FD has no field or method Dircookie)
/usr/local/go/src/internal/poll/fd_wasip1.go:207:38: invalid argument: "syscall".Dirent has no single field Namlen
/usr/local/go/src/internal/poll/fd_wasip1.go:207:95: syscall.Dirent{}.Namlen undefined (type "syscall".Dirent has no field or method Namlen)
/usr/local/go/src/internal/poll/fd_wasip1.go:211:38: invalid argument: "syscall".Dirent has no single field Next
/usr/local/go/src/internal/poll/fd_wasip1.go:211:93: syscall.Dirent{}.Next undefined (type "syscall".Dirent has no field or method Next)
/usr/local/go/src/internal/syscall/unix/at_wasip1.go:12:2: UTIME_OMIT redeclared in this block
/usr/local/go/src/internal/syscall/unix/at_sysnum_linux.go:18:2:        other declaration of UTIME_OMIT
/usr/local/go/src/time/zoneinfo_wasip1.go:8:5: platformZoneSources redeclared in this block
/usr/local/go/src/time/zoneinfo_unix.go:21:5:   other declaration of platformZoneSources
/usr/local/go/src/time/zoneinfo_wasip1.go:10:6: initLocal redeclared in this block
/usr/local/go/src/time/zoneinfo_unix.go:28:6:   other declaration of initLocal
```
The project I was using was already on Go `1.21`. Rebuilding the container with this version upgrade resolved the issue.